### PR TITLE
feat(api): update mainpage & get url

### DIFF
--- a/controllers/linkController.js
+++ b/controllers/linkController.js
@@ -1,0 +1,16 @@
+const linkService = require("../services/linkService");
+const error = require("../middlewares/errorConstructor");
+
+const getLink = async (req, res) => {
+  const surveyId = Number(req.params.id);
+  if (typeof surveyId !== "number") {
+    throw new error("surveyId must be number", 400);
+  }
+  await linkService.checkSurveyId(surveyId);
+  const surveyLink = await linkService.getLink(surveyId);
+  res.status(200).json({ surveyLink });
+};
+
+module.exports = {
+  getLink,
+};

--- a/controllers/mainController.js
+++ b/controllers/mainController.js
@@ -3,6 +3,7 @@ const error = require("../middlewares/errorConstructor");
 
 const getCount = async (req, res) => {
   const adminPkId = req.decoded.id;
+  await mainService.updateSurveyStatus(adminPkId);
   const mainPageCount = await mainService.getCount(adminPkId);
   res.status(200).json({ mainPageCount });
 };

--- a/models/database.js
+++ b/models/database.js
@@ -7,6 +7,7 @@ const database = new DataSource({
   username: process.env.TYPEORM_USERNAME,
   password: process.env.TYPEORM_PASSWORD,
   database: process.env.TYPEORM_DATABASE,
+  logging: true,
 });
 
 module.exports = {

--- a/models/linkDao.js
+++ b/models/linkDao.js
@@ -1,0 +1,40 @@
+const { database } = require("./database");
+
+const error = require("../middlewares/errorConstructor");
+
+const checkSurveyId = async (surveyId) => {
+  try {
+    return database.query(
+      `
+      SELECT EXISTS(
+        SELECT 
+          id 
+        from survey 
+        WHERE id = ?
+      ) AS RESULT`,
+      [surveyId]
+    );
+  } catch (err) {
+    throw new error("INVALID_DATA_INPUT", 500);
+  }
+};
+
+const getLink = async (surveyId) => {
+  try {
+    return await database.query(
+      `
+      SELECT 
+        survey_url AS surveyLink
+      FROM survey
+      WHERE id = ?`,
+      [surveyId]
+    );
+  } catch (err) {
+    throw new error("INVALID_DATA_INPUT", 500);
+  }
+};
+
+module.exports = {
+  checkSurveyId,
+  getLink,
+};

--- a/models/mainDao.js
+++ b/models/mainDao.js
@@ -17,6 +17,40 @@ const getCount = async (adminPkId) => {
   }
 };
 
+const getAllList = async (adminPkId) => {
+  try {
+    return await database.query(
+      `
+      SELECT 
+        id,
+        DATE_FORMAT(start_date, '%Y%m%d') AS start_date,
+        DATE_FORMAT(end_date, '%Y%m%d') AS end_date,
+        survey_status_id
+      FROM survey
+      WHERE survey.admin_id = ?
+      AND NOT survey_status_id = 3`,
+      [adminPkId]
+    );
+  } catch (err) {
+    throw new error("INVALID_DATA_INPUT", 500);
+  }
+};
+
+const updateSurveyStatus = async (statusId, surveyId) => {
+  try {
+    await database.query(
+      `
+      UPDATE 
+        survey
+      SET survey_status_id = ? 
+      WHERE id = ?`,
+      [statusId, surveyId]
+    );
+  } catch (err) {
+    throw new error("INVALID_DATA_INPUT", 500);
+  }
+};
+
 const getList = async (startPageNo, limit, adminPkId) => {
   try {
     return await database.query(
@@ -25,8 +59,8 @@ const getList = async (startPageNo, limit, adminPkId) => {
         survey.id,
         name,
         status,
-        DATE_FORMAT(start_date, '%Y-%c-%e') AS start_date,
-        DATE_FORMAT(end_date, '%Y-%c-%e') AS end_date,
+        DATE_FORMAT(start_date, '%Y-%m-%d') AS start_date,
+        DATE_FORMAT(end_date, '%Y-%m-%d') AS end_date,
         COUNT(opinion.id) AS count
       FROM survey
       INNER JOIN survey_status 
@@ -35,7 +69,7 @@ const getList = async (startPageNo, limit, adminPkId) => {
       ON survey.id = opinion.survey_id
       WHERE survey.admin_id = ?
       GROUP BY survey.id
-      ORDER BY survey_status_id
+      ORDER BY survey_status_id, survey.id DESC
       LIMIT ?, ?`,
       [adminPkId, startPageNo, limit]
     );
@@ -46,5 +80,7 @@ const getList = async (startPageNo, limit, adminPkId) => {
 
 module.exports = {
   getCount,
+  getAllList,
+  updateSurveyStatus,
   getList,
 };

--- a/routes/index.js
+++ b/routes/index.js
@@ -12,7 +12,7 @@ router.use("/main", mainRouter.router);
 
 router.use("/editor", editorRouter.router);
 
-router.use("/link", linkRouter.router); //미완성
+router.use("/link", linkRouter.router);
 
 router.use("/opinion", opinionRouter.router);
 

--- a/routes/linkRouter.js
+++ b/routes/linkRouter.js
@@ -5,7 +5,7 @@ const { validateToken } = require("../middlewares/auth.js");
 
 const router = express.Router();
 
-router.get("/", validateToken, errorHandler(linkController.getLink));
+router.get("/:id", validateToken, errorHandler(linkController.getLink));
 
 module.exports = {
   router,

--- a/services/editorService.js
+++ b/services/editorService.js
@@ -27,7 +27,7 @@ const makeLink = async (
     landingUrl
   );
   const surveyId = (await editorDao.getSurveyId())[0].id;
-  const surveyLink = `http://localhost:8000/link/${surveyId}`;
+  const surveyLink = `http://localhost:8000/user/${surveyId}`;
   await editorDao.SetSurveyLink(surveyId, surveyLink);
   return surveyLink;
 };

--- a/services/linkService.js
+++ b/services/linkService.js
@@ -1,0 +1,20 @@
+const linkDao = require("../models/linkDao");
+
+const error = require("../middlewares/errorConstructor");
+
+const checkSurveyId = async (surveyId) => {
+  const checkSurveyId = await linkDao.checkSurveyId(surveyId);
+  if (checkSurveyId[0].RESULT === "0") {
+    throw new error("surveyId KEY ERROR", 400);
+  }
+};
+
+const getLink = async (surveyId) => {
+  const surveyLink = await linkDao.getLink(surveyId);
+  return surveyLink[0].surveyLink;
+};
+
+module.exports = {
+  checkSurveyId,
+  getLink,
+};

--- a/services/mainService.js
+++ b/services/mainService.js
@@ -2,7 +2,24 @@ const mainDao = require("../models/mainDao");
 
 const getCount = async (adminPkId) => {
   const getCount = await mainDao.getCount(adminPkId);
-  return getCount;
+  return getCount[0].surveycount;
+};
+
+const updateSurveyStatus = async (adminPkId) => {
+  const getAllList = await mainDao.getAllList(adminPkId);
+  let today = new Date();
+  let date = Number(
+    String(today.getFullYear()) +
+      String(("0" + (today.getMonth() + 1)).slice(-2)) +
+      String(("0" + today.getDate()).slice(-2))
+  );
+  getAllList.forEach((list) => {
+    if (date < Number(list.start_date)) {
+      mainDao.updateSurveyStatus(2, list.id);
+    } else if (date > Number(list.end_date)) {
+      mainDao.updateSurveyStatus(3, list.id);
+    }
+  });
 };
 
 const getList = async (pageNo, limit, adminPkId) => {
@@ -13,5 +30,6 @@ const getList = async (pageNo, limit, adminPkId) => {
 
 module.exports = {
   getCount,
+  updateSurveyStatus,
   getList,
 };


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능 추가
- [x] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- 설문 url을 get 하는 api를 구현하였습니다.
- survey status를 자동 업데이트하는 기능을 구현하였습니다.
- 자잘한 버그를 수정하였습니다.

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

1. get 설문 url 기능

- survey id값을 통해 설문 url을 제공하는 기능을 구현하였습니다.
- id값은 메인 페이지 리스트 get할때 제공합니다.

2. survey status를 자동 업데이트하는 기능

- 처음 자바스크립트 date함수를 통해 현재 날짜를 가져오고 테이블에 저장된 date를 비교하여 status를 관리하는 기능을 구현하였습니다.
- 메인페이지의 count 요청시 survey의 상태를 가져오고 서비스단에서 foreach 구문을 통해 자동업데이트하는 기능을 구현하였습니다.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)

- 동적으로 status를 관리하는 기능을 구현하면서 테이블 관리 능력을 배웠습니다.

<br />

## :: 기타 질문 및 특이 사항

- //
