### PR TITLE
feat: statistic1

### DIFF
--- a/controllers/editorController.js
+++ b/controllers/editorController.js
@@ -37,13 +37,18 @@ const madeEditor = async (req, res) => {
 };
 
 const imageUploader = async (req, res) => {
+  if (!req.file) {
+    throw new error("image_upload_failed", 400);
+  }
+
   const imageLocation = `./uploads/${req.file.filename}`;
   editorService.setImage(imageLocation);
+
   res.status(201).json({ message: "success" });
 };
 
 const imageSender = async (req, res) => {
-  const absPath = await editorService.getImage(req.params.formId);
+  const absPath = await editorService.getImage(req.params.surveyId);
   res.sendFile(`${absPath[0].img}`, () => {});
 };
 

--- a/controllers/opinionController.js
+++ b/controllers/opinionController.js
@@ -3,26 +3,12 @@ const opinionService = require("../services/opinionService");
 
 const setOpinion = async (req, res) => {
   const { surveyId } = req.params;
-  const { result, phone, agreement } = req.body;
-
-  if (
-    !surveyId ||
-    !result ||
-    !phone ||
-    (typeof agreement !== "boolean" && agreement !== null)
-  ) {
-    throw new error(
-      `dev: surveyId ${surveyId}, result ${typeof result}, phone ${phone}, agreement ${agreement}`,
-      400
-    );
+  const { userData } = req.body;
+  if (!surveyId) {
+    throw new error("KEY_ERROR", 400);
   }
 
-  await opinionService.setOpinion(
-    surveyId,
-    result,
-    phone.match(/[0-9]/g).join(""),
-    agreement
-  );
+  await opinionService.setOpinion(Number(surveyId), JSON.stringify(userData));
 
   res.status(200).json({ message: "success" });
 };

--- a/controllers/statisticController.js
+++ b/controllers/statisticController.js
@@ -1,0 +1,24 @@
+const statisticService = require("../services/statisticService");
+const error = require("../middlewares/errorConstructor");
+
+const countSumOfParticipation = async (req, res) => {
+  if (!req.params) {
+    throw new error(`req.params: ${req.params}`, 400);
+  }
+
+  const { surveyId } = req.params;
+  const result = await statisticService.countSumOfParticipation(surveyId);
+
+  res.status(200).json(result);
+};
+
+const makeDataForStatSub = async (req, res) => {
+  const { surveyId } = req.params;
+  const result = await statisticService.makeDataForStat(surveyId);
+  res.status(200).json(result);
+};
+
+module.exports = {
+  countSumOfParticipation,
+  makeDataForStatSub,
+};

--- a/controllers/surveypageController.js
+++ b/controllers/surveypageController.js
@@ -9,7 +9,7 @@ const getSurveyPageData = async (req, res) => {
   }
 
   const result = await surveypageService.getSurveyPageData(surveyId);
-  res.status(200).json({ result });
+  res.status(200).json(result);
 };
 
 const checkDuplicateParticipate = async (req, res) => {

--- a/db/migrations/20221006055737_image_alter2_delete_fk.sql
+++ b/db/migrations/20221006055737_image_alter2_delete_fk.sql
@@ -1,0 +1,4 @@
+-- migrate:up
+
+ALTER TABLE
+    images DROP FOREIGN KEY image_ibfk_1 -- migrate:down

--- a/middlewares/imageUploader.js
+++ b/middlewares/imageUploader.js
@@ -16,7 +16,7 @@ const upload = multer({
     },
     filename(req, file, done) {
       const ext = path.extname(file.originalname);
-      where = path.basename(file.originalname, ext) + Date.now() + ext;
+      const where = Date.now() + ext;
       done(null, where);
     },
   }),

--- a/models/editorDao.js
+++ b/models/editorDao.js
@@ -34,6 +34,19 @@ const getImagesId = async () => {
         FROM images`);
 };
 
+const getSurveyId = async () => {
+  try {
+    return await database.query(
+      `
+      SELECT 
+        MAX(id) AS id 
+      FROM survey`
+    );
+  } catch (err) {
+    throw new error("INVALID_DATA_INPUT", 500);
+  }
+};
+
 const makeSurvey = async (
   adminPkId,
   formId,
@@ -69,6 +82,7 @@ const makeSurvey = async (
       ]
     );
     const imagesId = await getImagesId();
+
     await database.query(
       `
       UPDATE images
@@ -76,19 +90,6 @@ const makeSurvey = async (
       WHERE images.id = ?
       `,
       [formId, imagesId[0].id]
-    );
-  } catch (err) {
-    throw new error("INVALID_DATA_INPUT", 500);
-  }
-};
-
-const getSurveyId = async () => {
-  try {
-    return await database.query(
-      `
-      SELECT 
-        MAX(id) AS id 
-      FROM survey`
     );
   } catch (err) {
     throw new error("INVALID_DATA_INPUT", 500);
@@ -123,15 +124,23 @@ const setImage = async (absPath) => {
   );
 };
 
-const getImage = async (formId) => {
+const getImage = async (surveyId) => {
   try {
+    const formId = await database.query(
+      `
+    SELECT form_id
+    FROM survey 
+    WHERE survey.id = ?
+    `,
+      [surveyId]
+    );
     return await database.query(
       `
       SELECT img 
       FROM images 
       WHERE images.form_id =?
       `,
-      [formId]
+      [formId[0].form_id]
     );
   } catch (err) {
     throw new error("image get failed", 500);

--- a/models/opinionDao.js
+++ b/models/opinionDao.js
@@ -1,13 +1,13 @@
 const { database } = require("../models/database");
 
 const setOpinion = async (surveyId, result, phone, agreement) => {
-  database.query(
+  await database.query(
     `
         INSERT INTO opinion 
             (survey_id, 
-             result, 
-             phone, 
-             agreement)
+              result, 
+              phone, 
+              agreement)
         VALUES 
             (?,?,?,?)
     `,

--- a/models/statisticDao.js
+++ b/models/statisticDao.js
@@ -1,0 +1,60 @@
+const { database } = require("./database");
+
+const getSumParticipationSurvey = async (surveyId) => {
+  return await database.query(
+    `
+    SELECT COUNT(survey.id) as count,survey.id,start_date, end_date, survey_status.status as status
+    FROM opinion 
+    JOIN survey
+    ON survey.id = opinion.survey_id
+    JOIN survey_status
+    ON survey.survey_status_id = survey_status.id
+    WHERE survey.id = ?
+    `,
+    [surveyId]
+  );
+};
+
+const getOpinionResult = async (surveyId) => {
+  return await database.query(
+    `
+    SELECT result 
+    FROM opinion 
+    WHERE opinion.survey_id = ?
+    `,
+    [surveyId]
+  );
+};
+
+const getFormDataForQuestion = async (surveyId) => {
+  return await database.query(
+    `
+    SELECT form_data 
+    FROM form 
+    WHERE id= (SELECT form_id
+    FROM survey 
+    WHERE survey.id = ?)
+  `,
+    [surveyId]
+  );
+};
+
+const setPhoneAndAgreement = async (phone, agreement) => {
+  return await database.query(
+    `
+    INSERT INTO opinion (
+      phone, agreement
+    )VALUES (
+      ?,?
+    )
+    `,
+    [phone, agreement]
+  );
+};
+
+module.exports = {
+  getSumParticipationSurvey,
+  getOpinionResult,
+  getFormDataForQuestion,
+  setPhoneAndAgreement,
+};

--- a/models/surveypageDao.js
+++ b/models/surveypageDao.js
@@ -7,8 +7,8 @@ const getSurveyPageData = async (surveyId) => {
     form.form_data as formData, 
     survey.duplication_allow as duplicationAllow, 
     survey.anonymous_allow as anonymousAllow,
-    survey.start_date as startDate,
-    survey.end_date as endDate,
+    DATE_FORMAT(start_date, "%Y-%m-%d") as startDate,
+    DATE_FORMAT(end_date, "%Y-%m-%d") as endDate,
     survey.name
     FROM form
     JOIN survey 

--- a/routes/editorRouter.js
+++ b/routes/editorRouter.js
@@ -16,7 +16,7 @@ router.post(
 );
 
 router.get(
-  "/image/:formId",
+  "/image/:surveyId",
 
   errorHandler(editorController.imageSender)
 );

--- a/routes/index.js
+++ b/routes/index.js
@@ -6,6 +6,7 @@ const editorRouter = require("./editorRouter");
 const linkRouter = require("./linkRouter");
 const opinionRouter = require("./opinionRouter");
 const surveypageRouter = require("./surveypageRouter");
+const statisticRouter = require("./statisticRouter");
 
 router.use("/admin", adminRouter.router);
 
@@ -18,5 +19,7 @@ router.use("/link", linkRouter.router);
 router.use("/opinion", opinionRouter.router);
 
 router.use("/surveypage", surveypageRouter.router);
+
+router.use("/statistic", statisticRouter.router);
 
 module.exports = router;

--- a/routes/statisticRouter.js
+++ b/routes/statisticRouter.js
@@ -1,0 +1,19 @@
+const express = require("express");
+const statisticController = require("../controllers/statisticController");
+const errorHandler = require("../middlewares/errorHandler");
+
+const router = express.Router();
+
+router.get(
+  "/sum/:surveyId",
+  errorHandler(statisticController.countSumOfParticipation)
+);
+
+router.get(
+  "/subjective/:surveyId",
+  errorHandler(statisticController.makeDataForStatSub)
+);
+
+module.exports = {
+  router,
+};

--- a/services/editorService.js
+++ b/services/editorService.js
@@ -37,8 +37,8 @@ const setImage = async (imageLocation) => {
   await editorDao.setImage(absPath);
 };
 
-const getImage = async (formId) => {
-  const imagePath = await editorDao.getImage(formId);
+const getImage = async (surveyId) => {
+  const imagePath = await editorDao.getImage(surveyId);
   return imagePath;
 };
 

--- a/services/opinionService.js
+++ b/services/opinionService.js
@@ -1,8 +1,20 @@
 const opinionDao = require("../models/opinionDao");
 const error = require("../middlewares/errorConstructor");
 
-const setOpinion = async (surveyId, result, phone, agreement) => {
-  await opinionDao.setOpinion(surveyId, result, phone, agreement);
+const setOpinion = async (surveyId, userData) => {
+  const temp = JSON.parse(userData).filter(Boolean);
+  let phone = null,
+    agreement = null;
+  for (let val of temp) {
+    if (Object.hasOwn(val, "phone")) {
+      phone = val.phone;
+    }
+    if (Object.hasOwn(val, "agreement")) {
+      agreement = val.agreement;
+    }
+  }
+  console.log(phone, agreement);
+  return await opinionDao.setOpinion(surveyId, userData, phone, agreement);
 };
 
 module.exports = {

--- a/services/statisticService.js
+++ b/services/statisticService.js
@@ -1,0 +1,68 @@
+const statisticDao = require("../models/statisticDao");
+const error = require("../middlewares/errorConstructor");
+
+const countSumOfParticipation = async (surveyId) => {
+  if (Object.is(Number(surveyId), NaN)) {
+    throw new error(`surveyId: '${surveyId}', NOT_A_NUMBER`, 400);
+  }
+
+  const result = await statisticDao.getSumParticipationSurvey(surveyId);
+  return result[0];
+};
+
+const checkToSubjective = (val) => {
+  if (Object.hasOwn(val, "answer")) {
+    return val.answer;
+  } else if (Object.hasOwn(val, "answers")) {
+    return val.answers;
+  }
+};
+
+const makeDataForStat = async (surveyId) => {
+  const questions = await statisticDao.getFormDataForQuestion(surveyId);
+  const opinions = await statisticDao.getOpinionResult(surveyId);
+
+  const opinionArr = [];
+  const temp1 = {};
+  const result = [];
+
+  for (let val of opinions) {
+    opinionArr.push(JSON.parse(val.result).filter(Boolean));
+  }
+
+  const que = JSON.parse(questions[0].form_data).filter((val) => {
+    return !Object.hasOwn(val, "file");
+  });
+  console.log(opinionArr, que);
+  for (let i = 0; i < opinionArr.length; i++) {
+    opinionArr[i].forEach((val, x) => {
+      if (checkToSubjective(val)) {
+        const question = que[x]["question"];
+        const answer = val["answer"] || val["answers"];
+        temp1[question] =
+          temp1[question] === undefined
+            ? [answer]
+            : [...temp1[question], answer];
+      }
+    });
+  }
+
+  const key = Object.keys(temp1);
+  const value = Object.values(temp1);
+  const size = key.length;
+
+  for (let i = 0; i < size; i++) {
+    const temp2 = {};
+    temp2["id"] = i + 1;
+    temp2["question"] = key[i];
+    temp2["answer"] = value[i];
+    result.push(temp2);
+  }
+
+  return result;
+};
+
+module.exports = {
+  countSumOfParticipation,
+  makeDataForStat,
+};

--- a/services/surveypageService.js
+++ b/services/surveypageService.js
@@ -2,9 +2,8 @@ const surveypageDao = require("../models/surveypageDao");
 
 const getSurveyPageData = async (surveyId) => {
   const value = await surveypageDao.getSurveyPageData(surveyId);
-
   const result = {
-    formData: value[0].formData,
+    formData: JSON.parse(value[0].formData),
     etc: {
       duplicationAllow: value[0].duplicationAllow,
       anonymousAllow: value[0].anonymousAllow,
@@ -13,6 +12,7 @@ const getSurveyPageData = async (surveyId) => {
       name: value[0].name,
     },
   };
+  console.log(result);
   return result;
 };
 


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- 통계 처리를 위한 기능 구현
- 그외 자잘한 수정

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

1. opinion  api post: 고객 설문 응답 데이터가 서버로 들어올 때, 전화번호와 개인정보 제공 동의 여부를 데이터베이스에 기록하도록 기능을 수정했습니다. 
2. statistic api get: 관리자가 볼 수 있는 통계 페이지에 필요한 데이터(survey name, start_date, end_date, status)를 응답할 수 있도록 기능을 추가 했습니다. (url: /statistic/:surveyId)
3. statistic api get: 통계 페이지에서 응답자의 주관식 답변을 볼 수 있도록  기능을 구현했습니다. 주관식 답변은 통계 처리가 안되므로 관련된 답변을 모아서 관리자가 열람할 수 있도록 코드를 작성했습니다. (url: /statistic/subjective/:surveyId)

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)

- 데이터를 프론트 엔드 서버에서 손쉽게 쓸 수 있도록 가공 처리하는 방법을 고민했습니다.

<br />

## :: 기타 질문 및 특이 사항

- 예외처리를 하지 못해 다음 커밋에서 할 예정입니다. 